### PR TITLE
build: remove bulk type-check command

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,13 +26,6 @@ steps:
   depends_on:
     - install
 
-- name: type-check
-  image: node:gallium
-  commands:
-    - node common/scripts/install-run-rush.js type-check
-  depends_on:
-    - install
-
 - name: test
   image: node:gallium
   commands:
@@ -78,6 +71,5 @@ steps:
     - install
     - lint
     - lint:md
-    - type-check
     - test
     - build

--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ Run all project tests.
 rush test
 ```
 
-Type check all TS projects.
-
-```sh
-rush type-check
-```
-
 Scaffold a new JS project.
 
 ```sh

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --max-warnings=0 --fix --cache --cache-location node_modules/.cache/eslint-cache/ .",
     "lint:md": "markdownlint-cli2-config 'node_modules/@trshcmpctr/markdownlint-config/.markdownlint-cli2.jsonc' '**/*.md' '#node_modules'",
     "start": "webpack serve --config config/webpack.config.js",
-    "test": "jest --config=config/jest/jest.config.js --no-cache --reporters=@trshcmpctr/jest-stdout-reporter --silent",
+    "test": "npm run test:jest && npm run type-check",
+    "test:jest": "jest --config=config/jest/jest.config.js --no-cache --reporters=@trshcmpctr/jest-stdout-reporter --silent",
     "type-check": "tsc",
     "watch": "webpack --config config/webpack.config.js --watch"
   },

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -32,13 +32,6 @@
       "enableParallelism": true
     },
     {
-      "name": "type-check",
-      "summary": "Type check all projects",
-      "commandKind": "bulk",
-      "enableParallelism": true,
-      "ignoreMissingScript": true
-    },
-    {
       "name": "commitlint",
       "summary": "Used by the commit-msg Git hook. This command invokes commitlint to lint commit messages.",
       "commandKind": "global",


### PR DESCRIPTION
Consolidate type-checking into client test command since it's the only
TypeScript project in the repo.