### PR TITLE
test(client): replace custom transformer

### DIFF
--- a/client/config/jest/babel-jest.js
+++ b/client/config/jest/babel-jest.js
@@ -1,9 +1,0 @@
-// Custom transformer, purely to customize the location
-// of the Babel configuration file.
-// https://babeljs.io/docs/en/config-files#jest
-// https://jestjs.io/docs/en/tutorial-react#custom-transformers
-const babelJest = require('babel-jest').default;
-
-module.exports = babelJest.createTransformer({
-  configFile: require.resolve('../babel.config.js'),
-});

--- a/client/config/jest/jest.config.js
+++ b/client/config/jest/jest.config.js
@@ -11,7 +11,12 @@ module.exports = {
     // To workaround this, we configure Drone to remove src/ from the workspace base path.
     // But we also include the root directory in the transform pattern here (/client/src)
     // as an extra defense against transforming unintended files.
-    '\\/client\\/src\\/.+\\.[t|j]sx?$': '<rootDir>/config/jest/babel-jest.js',
+    '\\/client\\/src\\/.+\\.[t|j]sx?$': [
+      'babel-jest',
+      // Since the babel config isn't in the package root,
+      // we need to locate it explicitly for babel-jest here.
+      { configFile: require.resolve('../babel.config.js') }
+    ],
   },
   collectCoverage: true,
   testEnvironment: 'jsdom',


### PR DESCRIPTION
Turns out we don't need an entire custom transformer to pass the
location of the babel config to babel-jest, we can pass it as an option
from jest transform.