### PR TITLE
build: remove fixup for webpack-dev-middleware

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "test": "jest --reporters=@trshcmpctr/jest-stdout-reporter --silent",
     "test:debug": "NODE_OPTIONS=--inspect jest --runInBand --no-cache",
     "test:watch": "jest --watch",
-    "test:cypress": "start-server-and-test serve http://localhost:8080 cy:run",
+    "test:cypress": "start-server-and-test serve http-get://localhost:8080 cy:run",
     "type-check": "tsc",
     "watch": "webpack --config webpack.config.cjs --watch"
   },

--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -34,13 +34,5 @@ function readPackage(packageJson, context) {
   //  packageJson.dependencies['log4js'] = '0.6.38';
   // }
 
-  if (packageJson.name === '@trshcmpctr/client') {
-    // Running into an issue with latest minor version of webpack-dev-middleware
-    // Possibly an interaction with start-server-and-test but downgrading helps
-    // https://github.com/webpack/webpack-dev-middleware/issues/1920
-    packageJson.dependencies['webpack-dev-middleware'] = '7.2.1';
-    context.log('Fixed up @trshcmpctr/client dependency, webpack-dev-middleware');
-  }
-
   return packageJson;
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       react-router-dom:
         specifier: ~6.26.1
         version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      webpack-dev-middleware:
-        specifier: 7.2.1
-        version: 7.2.1(webpack@5.93.0(webpack-cli@5.1.4))
     devDependencies:
       '@babel/core':
         specifier: ~7.25.2
@@ -2085,10 +2082,6 @@ packages:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@typescript-eslint/scope-manager@7.18.0':
-    resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-
   '@typescript-eslint/scope-manager@8.1.0':
     resolution: {integrity: sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2106,10 +2099,6 @@ packages:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@typescript-eslint/types@7.18.0':
-    resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-
   '@typescript-eslint/types@8.1.0':
     resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2117,15 +2106,6 @@ packages:
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/typescript-estree@7.18.0':
-    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2147,12 +2127,6 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@typescript-eslint/utils@7.18.0':
-    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-
   '@typescript-eslint/utils@8.1.0':
     resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2162,10 +2136,6 @@ packages:
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@typescript-eslint/visitor-keys@7.18.0':
-    resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/visitor-keys@8.1.0':
     resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
@@ -6387,8 +6357,8 @@ packages:
       webpack-dev-server:
         optional: true
 
-  webpack-dev-middleware@7.2.1:
-    resolution: {integrity: sha512-hRLz+jPQXo999Nx9fXVdKlg/aehsw1ajA9skAneGmT03xwmyuhvF93p6HUKKbWhXdcERtGTzUCtIQr+2IQegrA==}
+  webpack-dev-middleware@7.3.0:
+    resolution: {integrity: sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: ^5.0.0
@@ -8978,11 +8948,6 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/scope-manager@7.18.0':
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-
   '@typescript-eslint/scope-manager@8.1.0':
     dependencies:
       '@typescript-eslint/types': 8.1.0
@@ -9002,8 +8967,6 @@ snapshots:
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/types@7.18.0': {}
-
   '@typescript-eslint/types@8.1.0': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.4)':
@@ -9015,21 +8978,6 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.3
       tsutils: 3.21.0(typescript@5.5.4)
-    optionalDependencies:
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.6(supports-color@5.5.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -9065,17 +9013,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
-      eslint: 8.57.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@8.1.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -9090,11 +9027,6 @@ snapshots:
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.3
-
-  '@typescript-eslint/visitor-keys@7.18.0':
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
   '@typescript-eslint/visitor-keys@8.1.0':
@@ -10547,7 +10479,7 @@ snapshots:
 
   eslint-plugin-jest@28.8.0(@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(jest@29.7.0)(typescript@5.5.4):
     dependencies:
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -13978,7 +13910,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.93.0)
 
-  webpack-dev-middleware@7.2.1(webpack@5.93.0(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.3.0(webpack@5.93.0(webpack-cli@5.1.4)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.11.1
@@ -14019,7 +13951,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.93.0(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.3.0(webpack@5.93.0(webpack-cli@5.1.4))
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "bdfce6abf9517ed147420f980b19f42b89aa1970",
+  "pnpmShrinkwrapHash": "a1507f65d5528c2263c45a719273a29f73008588",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
EDIT: Minimal reproduction:

```sh
# in /client
npm run serve
# from another terminal
curl --head http://localhost:8080
```

Related: https://github.com/bahmutov/start-server-and-test/blob/8ebb70b7b2be40b4b1b2f08d0b9c3ef51dfaca10/README.md#note-for-webpack-dev-server-users

> If you are using `webpack-dev-server` (directly or via angular/cli or other boilerplates) then the server does not respond to HEAD requests...

---

example CI failure: https://github.com/shanedg/trshcmpctr/actions/runs/10444385826/job/28918870422

```sh
==[ @trshcmpctr/client ]==========================================[ 9 of 11 ]==

This project does not define the caching behavior of the "test:cypress" command, so caching has been disabled.
Invoking: start-server-and-test serve http://localhost:8080 cy:run 
1: starting server using command "npm run serve"
and when url "[ 'http://localhost:8080' ]" is responding with HTTP status code 200
running tests using command "npm run cy:run"


> @trshcmpctr/client@1.0.0 serve
> webpack serve --config webpack.config.cjs

<i> [webpack-dev-server] Project is running at:
<i> [webpack-dev-server] Loopback: http://localhost:8080/
<i> [webpack-dev-server] On Your Network (IPv4): http://10.1.0.12:8080/
<i> [webpack-dev-server] Content not from webpack is served from '/home/runner/work/trshcmpctr/trshcmpctr/client/public' directory
<i> [webpack-dev-server] 404s will fallback to '/index.html'
<i> [webpack-dev-middleware] wait until bundle finished: /
<i> [webpack-dev-middleware] wait until bundle finished: /
<i> [webpack-dev-middleware] wait until bundle finished: /
asset main.833ffe118d92a1da7dc6.js 5.4 MiB [emitted] [immutable] (name: main)
asset favicon.ico 1.12 KiB [emitted]
asset index.html 322 bytes [emitted]
asset manifest.json 109 bytes [emitted]
runtime modules 28.7 KiB 15 modules
orphan modules [68](https://github.com/shanedg/trshcmpctr/actions/runs/10444385826/job/28918870422?pr=104#step:5:69)1 bytes [orphan] 1 module
modules by path ../common/temp/node_modules/.pnpm/ 1.78 MiB 265 modules
modules by path ./src/ 32.5 KiB
  modules by path ./src/App/ 23.6 KiB
    modules by path ./src/App/components/*.tsx 8.82 KiB 11 modules
    modules by path ./src/App/*.css 4.16 KiB 2 modules
    modules by path ./src/App/hooks/*.ts 9.12 KiB 2 modules
    + 1 module
  modules by path ./src/*.css 8.57 KiB
    ./src/reset.css 2.99 KiB [built] [code generated]
    ./src/style.css 2.99 KiB [built] [code generated]
    ../common/temp/node_modules/.pnpm/css-loader@7.1.2_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/css-loader/dist/cjs.js!./src/reset.css 1.78 KiB [built] [code generated]
    ../common/temp/node_modules/.pnpm/css-loader@7.1.2_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/css-loader/dist/cjs.js!./src/style.css 841 bytes [built] [code generated]
  ./src/index.ts 401 bytes [built] [code generated]
webpack 5.93.0 compiled successfully in 6538 ms
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:405:5)
    at ServerResponse.setHeader (node:_http_outgoing:648:11)
    at setResponseHeader (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/webpack-dev-middleware@7.3.0_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/webpack-dev-middleware/dist/utils/compatibleAPI.js:120:14)
    at processRequest (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/webpack-dev-middleware@7.3.0_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/webpack-dev-middleware/dist/middleware.js:599:7)
    at ready (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/webpack-dev-middleware@7.3.0_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/webpack-dev-middleware/dist/utils/ready.js:16:5)
    at middleware (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/webpack-dev-middleware@7.3.0_webpack@5.93.0_webpack-cli@5.1.4_/node_modules/webpack-dev-middleware/dist/middleware.js:640:5)
    at Layer.handle [as handle_request] (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:328:13)
    at /home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:346:12)
    at next (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:280:10)
    at /home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/connect-history-api-fallback@2.0.0/node_modules/connect-history-api-fallback/lib/index.js:85:5
    at Layer.handle [as handle_request] (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:328:13)
    at /home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:346:12)
    at next (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/index.js:280:10)
    at SendStream.error (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/serve-static@1.15.0/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (node:events:517:28)
    at SendStream.error (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/send@0.18.0/node_modules/send/index.js:270:17)
    at SendStream.onStatError (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/send@0.18.0/node_modules/send/index.js:417:12)
    at next (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/send@0.18.0/node_modules/send/index.js:759:28)
    at /home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/send@0.18.0/node_modules/send/index.js:767:23
    at FSReqCallback.oncomplete (node:fs:202:21) {
  code: 'ERR_HTTP_HEADERS_SENT'
}

Node.js v18.20.4

> @trshcmpctr/client@1.0.0 cy:run
> cypress run --config-file=cypress/cypress.config.ts

It looks like this is your first time using Cypress: 13.13.3

[STARTED] Task without title.
[SUCCESS] Task without title.

Opening Cypress...

DevTools listening on ws://127.0.0.1:44559/devtools/browser/786b8786-b39a-421e-8158-0a44482a3e9a
(node:22[69](https://github.com/shanedg/trshcmpctr/actions/runs/10444385826/job/28918870422?pr=104#step:5:70)) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("file%3A///home/runner/.cache/Cypress/13.13.3/Cypress/resources/app/node_modules/ts-node/esm/transpile-only.mjs", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:2269) ExperimentalWarning: The Node.js specifier resolution flag is experimental. It could change or be removed at any time.
(node:2269) ExperimentalWarning: The Node.js specifier resolution flag is experimental. It could change or be removed at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
Cypress could not verify that this server is running:

  > http://localhost:[80](https://github.com/shanedg/trshcmpctr/actions/runs/10444385826/job/28918870422?pr=104#step:5:81)80

We are verifying this server because it has been configured as your baseUrl.

Cypress automatically waits until your server is accessible before running tests.

We will try connecting to it 3 more times...
We will try connecting to it 2 more times...
We will try connecting to it 1 more time...

Cypress failed to verify that your server is running.

Please start this server and then run Cypress again.
Error: Command failed with exit code 1: npm run cy:run
    at makeError (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/execa@5.1.1/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/home/runner/work/trshcmpctr/trshcmpctr/common/temp/node_modules/.pnpm/execa@5.1.1/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  shortMessage: 'Command failed with exit code 1: npm run cy:run',
  command: 'npm run cy:run',
  escapedCommand: '"npm run cy:run"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
Returned error code: 1
"@trshcmpctr/client" failed to build.
"@trshcmpctr/discord" is blocked by "@trshcmpctr/client".
```